### PR TITLE
Try to fix mint preseed file.

### DIFF
--- a/mint_18_3.seed
+++ b/mint_18_3.seed
@@ -38,7 +38,13 @@ d-i passwd/user-password password password
 d-i passwd/user-password-again password password
 d-i netcfg/get_hostname string freegeekchicago
 
+### Boot loader installation
+# Make grub install automatically to the MBR
+# if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
 ### Finishing up the installation
 # Avoid that last message about the install being complete.
 ubiquity ubiquity/summary note
-ubiquity ubiquity/reboot boolean true
+# Uncomment the below line to skip the 'restart now' dialog
+# ubiquity ubiquity/reboot boolean true


### PR DESCRIPTION
When I tried the preseed file a couple weeks ago on a freegeek machine, it booted to a black screen with a flashing cursor. Usually this happens when the bootloader is missing. Well it turns out that... yes, I forgot to tell the installer to install the bootloader... 😬. Weirdly enough, VMWare boots even if I don't install the bootloader, which is why I never noticed this issue when I was testing the preseed file on a virtual machine.